### PR TITLE
Better support for the 268 chip

### DIFF
--- a/os/common/ext/SN/SN32F26x/SN32F260.h
+++ b/os/common/ext/SN/SN32F26x/SN32F260.h
@@ -6,7 +6,7 @@
  *           SN32F260 from SONiX Technology Co., Ltd..
  *
  * @version  V1.1
- * @date     22. March 2017
+ * @date     19. March 2019
  *
  * @note     Generated with SVDConv V2.87e 
  *           from CMSIS SVD File 'SN32F260.svd' Version 1.1,
@@ -1726,7 +1726,9 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
     __IO uint32_t  MCTRL3;                          /*!< Offset:0x1C CT16Bn Match Control Register                             */
     
     struct {
-           uint32_t             :  3;
+      __IO uint32_t  MR20IE     :  1;               /*!< Enable generating an interrupt when MR20 matches TC                   */
+      __IO uint32_t  MR20RST    :  1;               /*!< Enable reset TC when MR20 matches TC                                  */
+      __IO uint32_t  MR20STOP   :  1;               /*!< Stop TC and PC and clear CEN bit when MR20 matches TC                 */
       __IO uint32_t  MR21IE     :  1;               /*!< Enable generating an interrupt when MR21 matches TC                   */
       __IO uint32_t  MR21RST    :  1;               /*!< Enable reset TC when MR21 matches TC                                  */
       __IO uint32_t  MR21STOP   :  1;               /*!< Stop TC and PC and clear CEN bit when MR21 matches TC                 */
@@ -1758,61 +1760,62 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
   __IO uint32_t  MR17;                              /*!< Offset:0x64 CT16Bn MR17 Register                                      */
   __IO uint32_t  MR18;                              /*!< Offset:0x68 CT16Bn MR18 Register                                      */
   __IO uint32_t  MR19;                              /*!< Offset:0x6C CT16Bn MR19 Register                                      */
-  __I  uint32_t  RESERVED1;
+  __IO uint32_t  MR20;                              /*!< Offset:0x70 CT16Bn MR20 Register                                      */
   __IO uint32_t  MR21;                              /*!< Offset:0x74 CT16Bn MR21 Register                                      */
   __IO uint32_t  MR22;                              /*!< Offset:0x78 CT16Bn MR22 Register                                      */
   __IO uint32_t  MR23;                              /*!< Offset:0x7C CT16Bn MR23 Register                                      */
-  __I  uint32_t  RESERVED2[2];
+  __I  uint32_t  RESERVED1[2];
   
   union {
     __IO uint32_t  EM;                              /*!< Offset:0x88 CT16Bn External Match Register                            */
     
     struct {
-      __IO uint32_t  EM0        :  1;               /*!< When the TC matches MR0, this bit will act according to EMC0[1:0],
-                                                         and also drive the state of CT16Bn_PWM0 output.                       */
-      __IO uint32_t  EM1        :  1;               /*!< When the TC matches MR1, this bit will act according to EMC1[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM2        :  1;               /*!< When the TC matches MR2, this bit will act according to EMC2[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
-      __IO uint32_t  EM3        :  1;               /*!< When the TC matches MR3, this bit will act according to EMC3[1:0],
-                                                         and also drive the state of CT16Bn_PWM3 output.                       */
-      __IO uint32_t  EM4        :  1;               /*!< When the TC matches MR4, this bit will act according to EMC4[1:0],
-                                                         and also drive the state of CT16Bn_PWM0 output.                       */
-      __IO uint32_t  EM5        :  1;               /*!< When the TC matches MR5, this bit will act according to EMC5[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM6        :  1;               /*!< When the TC matches MR6, this bit will act according to EMC6[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
-      __IO uint32_t  EM7        :  1;               /*!< When the TC matches MR7, this bit will act according to EMC7[1:0],
-                                                         and also drive the state of CT16Bn_PWM3 output.                       */
-      __IO uint32_t  EM8        :  1;               /*!< When the TC matches MR8, this bit will act according to EMC8[1:0],
-                                                         and also drive the state of CT16Bn_PWM0 output.                       */
-      __IO uint32_t  EM9        :  1;               /*!< When the TC matches MR9, this bit will act according to EMC9[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM10       :  1;               /*!< When the TC matches MR10, this bit will act according to EMC10[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
-      __IO uint32_t  EM11       :  1;               /*!< When the TC matches MR11, this bit will act according to EMC11[1:0],
-                                                         and also drive the state of CT16Bn_PWM3 output.                       */
-      __IO uint32_t  EM12       :  1;               /*!< When the TC matches MR12, this bit will act according to EMC12[1:0],
-                                                         and also drive the state of CT16Bn_PWM0 output.                       */
-      __IO uint32_t  EM13       :  1;               /*!< When the TC matches MR13, this bit will act according to EMC13[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM14       :  1;               /*!< When the TC matches MR14, this bit will act according to EMC14[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
-      __IO uint32_t  EM15       :  1;               /*!< When the TC matches MR15, this bit will act according to EMC15[1:0],
-                                                         and also drive the state of CT16Bn_PWM3 output.                       */
-      __IO uint32_t  EM16       :  1;               /*!< When the TC matches MR16, this bit will act according to EMC16[1:0],
-                                                         and also drive the state of CT16Bn_PWM0 output.                       */
-      __IO uint32_t  EM17       :  1;               /*!< When the TC matches MR17, this bit will act according to EMC17[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM18       :  1;               /*!< When the TC matches MR18, this bit will act according to EMC18[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
-      __IO uint32_t  EM19       :  1;               /*!< When the TC matches MR19, this bit will act according to EMC19[1:0],
-                                                         and also drive the state of CT16Bn_PWM3 output.                       */
-           uint32_t             :  1;
-      __IO uint32_t  EM21       :  1;               /*!< When the TC matches MR21, this bit will act according to EMC21[1:0],
-                                                         and also drive the state of CT16Bn_PWM1 output.                       */
-      __IO uint32_t  EM22       :  1;               /*!< When the TC matches MR22, this bit will act according to EMC22[1:0],
-                                                         and also drive the state of CT16Bn_PWM2 output.                       */
+      __IO uint32_t  EM0        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM0
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM1        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM1
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM2        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM2
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM3        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM3
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM4        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM4
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM5        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM5
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM6        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM6
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM7        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM7
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM8        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM8
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM9        :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM9
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM10       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM10
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM11       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM11
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM12       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM12
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM13       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM13
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM14       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM14
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM15       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM15
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM16       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM16
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM17       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM17
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM18       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM18
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM19       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM19
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM20       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM20
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM21       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM21
+                                                         output high or Low.                                                   */
+      __IO uint32_t  EM22       :  1;               /*!< When FW write this bit 1/0, MCU will drive the state of CT16Bn_PWM22
+                                                         output high or Low.                                                   */
     } EM_b;                                         /*!< BitSize                                                               */
   };
   
@@ -1847,7 +1850,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __IO uint32_t  EMC17      :  2;               /*!< CT16Bn_PWM17 functionality                                            */
       __IO uint32_t  EMC18      :  2;               /*!< CT16Bn_PWM18 functionality                                            */
       __IO uint32_t  EMC19      :  2;               /*!< CT16Bn_PWM19 functionality                                            */
-           uint32_t             :  2;
+      __IO uint32_t  EMC20      :  2;               /*!< CT16Bn_PWM20 functionality                                            */
       __IO uint32_t  EMC21      :  2;               /*!< CT16Bn_PWM21 functionality                                            */
       __IO uint32_t  EMC22      :  2;               /*!< CT16Bn_PWM22 functionality                                            */
     } EMC2_b;                                       /*!< BitSize                                                               */
@@ -1884,7 +1887,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __IO uint32_t  PWM17MODE  :  2;               /*!< PWM17 output mode                                                     */
       __IO uint32_t  PWM18MODE  :  2;               /*!< PWM18 output mode                                                     */
       __IO uint32_t  PWM19MODE  :  2;               /*!< PWM19 output mode                                                     */
-           uint32_t             :  2;
+      __IO uint32_t  PWM20MODE  :  2;               /*!< PWM20 output mode                                                     */
       __IO uint32_t  PWM21MODE  :  2;               /*!< PWM21 output mode                                                     */
       __IO uint32_t  PWM22MODE  :  2;               /*!< PWM22 output mode                                                     */
     } PWMCTRL2_b;                                   /*!< BitSize                                                               */
@@ -1914,7 +1917,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __IO uint32_t  PWM17EN    :  1;               /*!< PWM17 enable                                                          */
       __IO uint32_t  PWM18EN    :  1;               /*!< PWM18 enable                                                          */
       __IO uint32_t  PWM19EN    :  1;               /*!< PWM19 enable                                                          */
-           uint32_t             :  1;
+      __IO uint32_t  PWM20EN    :  1;               /*!< PWM20 enable                                                          */
       __IO uint32_t  PWM21EN    :  1;               /*!< PWM21 enable                                                          */
       __IO uint32_t  PWM22EN    :  1;               /*!< PWM22 enable                                                          */
     } PWMENB_b;                                     /*!< BitSize                                                               */
@@ -1944,7 +1947,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __IO uint32_t  PWM17IOEN  :  1;               /*!< CT16Bn_PWM17/GPIO selection                                           */
       __IO uint32_t  PWM18IOEN  :  1;               /*!< CT16Bn_PWM18/GPIO selection                                           */
       __IO uint32_t  PWM19IOEN  :  1;               /*!< CT16Bn_PWM19/GPIO selection                                           */
-           uint32_t             :  1;
+      __IO uint32_t  PWM20IOEN  :  1;               /*!< CT16Bn_PWM20/GPIO selection                                           */
       __IO uint32_t  PWM21IOEN  :  1;               /*!< CT16Bn_PWM21/GPIO selection                                           */
       __IO uint32_t  PWM22IOEN  :  1;               /*!< CT16Bn_PWM22/GPIO selection                                           */
     } PWMIOENB_b;                                   /*!< BitSize                                                               */
@@ -1974,7 +1977,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __I  uint32_t  MR17IF     :  1;               /*!< Match channel 17 interrupt flag                                       */
       __I  uint32_t  MR18IF     :  1;               /*!< Match channel 18 interrupt flag                                       */
       __I  uint32_t  MR19IF     :  1;               /*!< Match channel 19 interrupt flag                                       */
-           uint32_t             :  1;
+      __I  uint32_t  MR20IF     :  1;               /*!< Match channel 20 interrupt flag                                       */
       __I  uint32_t  MR21IF     :  1;               /*!< Match channel 21 interrupt flag                                       */
       __I  uint32_t  MR22IF     :  1;               /*!< Match channel 22 interrupt flag                                       */
       __I  uint32_t  MR23IF     :  1;               /*!< Match channel 23 interrupt flag                                       */
@@ -2005,7 +2008,7 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __O  uint32_t  MR17IC     :  1;               /*!< MR17IF clear bit                                                      */
       __O  uint32_t  MR18IC     :  1;               /*!< MR18IF clear bit                                                      */
       __O  uint32_t  MR19IC     :  1;               /*!< MR19IF clear bit                                                      */
-           uint32_t             :  1;
+      __O  uint32_t  MR20IC     :  1;               /*!< MR20IF clear bit                                                      */
       __O  uint32_t  MR21IC     :  1;               /*!< MR21IF clear bit                                                      */
       __O  uint32_t  MR22IC     :  1;               /*!< MR22IF clear bit                                                      */
       __O  uint32_t  MR23IC     :  1;               /*!< MR23IF clear bit                                                      */
@@ -2334,6 +2337,21 @@ typedef struct {                                    /*!< SN_FLASH Structure     
 } SN_FLASH_Type;
 
 
+/* ================================================================================ */
+/* ================                      SN_UC                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief UC Registers (SN_UC)
+  */
+
+typedef struct {                                    /*!< SN_UC Structure                                                       */
+  __I  uint32_t  L4BYTE;                            /*!< Offset:0x00 UC Low 4 Byte Register                                    */
+  __I  uint32_t  H4BYTE;                            /*!< Offset:0x04 UC High 4 Byte Register                                   */
+} SN_UC_Type;
+
+
 /* --------------------  End of section using anonymous unions  ------------------- */
 #if defined(__CC_ARM)
   #pragma pop
@@ -2370,6 +2388,7 @@ typedef struct {                                    /*!< SN_FLASH Structure     
 #define SN_SPI0_BASE                    0x4001C000UL
 #define SN_I2C0_BASE                    0x40018000UL
 #define SN_FLASH_BASE                   0x40062000UL
+#define SN_UC_BASE                      0x1FFF2220UL
 
 
 /* ================================================================================ */
@@ -2390,6 +2409,7 @@ typedef struct {                                    /*!< SN_FLASH Structure     
 #define SN_SPI0                         ((SN_SPI0_Type            *) SN_SPI0_BASE)
 #define SN_I2C0                         ((SN_I2C0_Type            *) SN_I2C0_BASE)
 #define SN_FLASH                        ((SN_FLASH_Type           *) SN_FLASH_BASE)
+#define SN_UC                           ((SN_UC_Type              *) SN_UC_BASE)
 
 
 /** @} */ /* End of group Device_Peripheral_Registers */

--- a/os/common/ext/SN/SN32F26x/SN32F260.h
+++ b/os/common/ext/SN/SN32F26x/SN32F260.h
@@ -1738,6 +1738,16 @@ typedef struct {                                    /*!< SN_CT16B1 Structure    
       __IO uint32_t  MR23IE     :  1;               /*!< Enable generating an interrupt when MR23 matches TC                   */
       __IO uint32_t  MR23RST    :  1;               /*!< Enable reset TC when MR23 matches TC                                  */
       __IO uint32_t  MR23STOP   :  1;               /*!< Stop TC and PC and clear CEN bit when MR23 matches TC                 */
+      /* 
+       * WARNING: 
+       * 
+       * This is just a temporary fix to make the code compile. MR24IE doesn't exist in hardware but will always read as 0.
+       * 
+       * As soon as the 268 is split off from the 248 code, the three MR24 lines below must be removed!
+       */ 
+      __IO uint32_t  MR24IE     :  1;               /*!< Enable generating an interrupt when MR2$ matches TC                   */ 
+      __IO uint32_t  MR24RST    :  1;               /*!< Enable reset TC when MR24 matches TC                                  */ 
+      __IO uint32_t  MR24STOP   :  1;               /*!< Stop TC and PC and clear CEN bit when MR24 matches TC                 */ 
     } MCTRL3_b;                                     /*!< BitSize                                                               */
   };
   __IO uint32_t  MR0;                               /*!< Offset:0x20 CT16Bn MR0 Register                                       */

--- a/os/hal/ports/SN32/SN32F260/platform.mk
+++ b/os/hal/ports/SN32/SN32F260/platform.mk
@@ -24,9 +24,9 @@ else
 endif
 
 # Drivers compatible with the platform.
-include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/GPIO/driver.mk
-include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/USB/driver.mk
-include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/CT/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/SN32F24xB/GPIO/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/SN32F24xB/USB/driver.mk
+include ${CHIBIOS_CONTRIB}/os/hal/ports/SN32/LLD/SN32F24xB/CT/driver.mk
 
 
 # include $(CHIBIOS)/os/hal/ports/SN32/LLD/TIM/driver.mk


### PR DESCRIPTION
The 268-specific code contains some bugs which makes it impossible to compile firmware for 268-based boards.

In order to improve the situation I did two things:

* Update the file SN32F260.h to its latest released version
* Applied some fixes found in https://github.com/Diff-fusion/ChibiOS-Contrib/commit/5c2bb9507a0ea2647781b882d330c56d9f22a0c7

The newest version of SN32F260.h can be obtained by doing the following:

* download the file "SN32F260_Startkit_Package_V1.6R.zip" from one of these two links: http://www.sonix.com.tw/article-en-998-24753 or http://www.sonix.com.tw/files/1/9BB279642CFC9359E050007F01007A12
* extract the file into a folder and search for a file called "SONiX.SN32F2_DFP.1.2.11.pack" in the folder "Pack"
* Rename that filet to "SONiX.SN32F2_DFP.1.2.11.zip" and extract it
* the file "SN32F260.h" is located in the folder "Device/Include"

