### PR TITLE
Line up SN32F260

### DIFF
--- a/os/common/ext/SN/SN32F26x/system_SN32F260.c
+++ b/os/common/ext/SN/SN32F26x/system_SN32F260.c
@@ -1,0 +1,202 @@
+/******************************************************************************
+ * @file     system_SN32F260.c
+ * @brief    CMSIS Cortex-M0 Device Peripheral Access Layer Source File
+ *           for the SONIX SN32F240B Devices
+ * @version  V1.0.3
+ * @date     2018/09/18
+ *
+ * @note
+ * Copyright (C) 2014-2018 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+
+#include <stdint.h>
+#include <SN32F260.h>
+#include <mcuconf.h>
+
+
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- Clock Configuration ----------------------------------
+//
+//<e> System Clock Configuration
+//		<o1>   SYSCLKSEL (SYS0_CLKCFG)
+//					<0=> IHRC=48MHz
+//					<1=> ILRC
+//
+//		<o2>   AHB Clock Prescaler Register  (SYS0_AHBCP)
+//					<0=> SYSCLK/1
+//					<1=> SYSCLK/2
+//					<2=> SYSCLK/4
+//					<3=> SYSCLK/8
+//					<4=> SYSCLK/16
+//					<5=> SYSCLK/32
+//					<6=> SYSCLK/64
+//					<7=> SYSCLK/128
+//
+//		<o3>  CLKOUT selection
+//					<0=> Disable
+//					<1=> ILRC
+//					<4=> HCLK
+//					<5=> IHRC
+//
+//		<o4>  CLKOUT Prescaler Register  (SYS1_APBCP1)
+//					<0=> CLKOUT/1
+//					<1=> CLKOUT/2
+//					<2=> CLKOUT/4
+//					<3=> CLKOUT/8
+//					<4=> CLKOUT/16
+//					<5=> CLKOUT/32
+//					<6=> CLKOUT/64
+//					<7=> CLKOUT/128
+//</e>
+*/
+#ifndef SYS_CLOCK_SETUP
+#define SYS_CLOCK_SETUP		1
+#endif
+#ifndef SYS0_CLKCFG_VAL
+#define SYS0_CLKCFG_VAL		0
+#endif
+#ifndef AHB_PRESCALAR
+#define AHB_PRESCALAR 		0x2
+#endif
+#ifndef CLKOUT_SEL_VAL
+#define CLKOUT_SEL_VAL 		0x0
+#endif
+#ifndef CLKOUT_PRESCALAR
+#define CLKOUT_PRESCALAR 	0x0
+#endif
+
+/*
+//-------- <<< end of configuration section >>> ------------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  DEFINES
+ *----------------------------------------------------------------------------*/
+#ifndef IHRC48
+#define	IHRC48						0
+#endif
+#ifndef ILRC
+#define	ILRC			  			1
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define __IHRC48_FREQ			(48000000UL)
+#define __ILRC_FREQ				(32000UL)
+
+
+/*----------------------------------------------------------------------------
+  Clock Variable definitions
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock;	/*!< System Clock Frequency (Core Clock)*/
+
+
+/*----------------------------------------------------------------------------
+  Clock functions
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
+{
+	uint32_t AHB_prescaler = 0;
+	uint32_t sys_clk = 0;
+
+	switch (SN_SYS0->CLKCFG_b.SYSCLKST) {
+		case 0:		//IHRC
+			sys_clk = __IHRC48_FREQ;
+			break;
+		case 1:		//ILRC
+			sys_clk = __ILRC_FREQ;
+			break;
+		default:
+			break;
+	}
+
+	switch (SN_SYS0->AHBCP_b.AHBPRE) {
+		case 0:	AHB_prescaler = 1;	break;
+		case 1:	AHB_prescaler = 2;	break;
+		case 2:	AHB_prescaler = 4;	break;
+		case 3:	AHB_prescaler = 8;	break;
+		case 4:	AHB_prescaler = 16;	break;
+		case 5:	AHB_prescaler = 32;	break;
+		case 6:	AHB_prescaler = 64;	break;
+		case 7:	AHB_prescaler = 128;break;
+		default: break;
+	}
+
+	SystemCoreClock = sys_clk / AHB_prescaler;
+
+	return;
+}
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System.
+ */
+void SystemInit (void)
+{
+#if (SYS_CLOCK_SETUP)
+
+	// Setup pre-scaler so HCLK is always less than 24MHz, this way it's save to configure LPCTRL.
+	// NOTE: This assumes it save to select >=24MHz mode while HCLK is <24MHz. LPCTRL most likely configures flash wait states, and in that case the assumption holds.
+	// SYSCLK will be IHRC or ILRC, both are less then 24MHz when divided by 4.
+	SN_SYS0->AHBCP = 2; // SYSCLK/4
+
+	#if SYS0_CLKCFG_VAL == IHRC48			//IHRC=48MHz
+		// Config flash based on HCLK
+		#if (AHB_PRESCALAR == 0 | AHB_PRESCALAR == 1)
+			SN_FLASH->LPCTRL = 0x5AFA0005; // >= 24MHz
+		#else
+			SN_FLASH->LPCTRL = 0x5AFA0000; // < 24MHz
+		#endif
+
+		// Start and make sure IHRC is running
+        SN_SYS0->ANBCTRL = 0x1;
+        while ((SN_SYS0->CSST & 0x1) != 0x1);
+
+		// Switch to IHRC
+        SN_SYS0->CLKCFG = 0x0;
+        while ((SN_SYS0->CLKCFG & 0x70) != 0x0);
+
+    #elif SYS0_CLKCFG_VAL == ILRC			//ILRC ON
+		// // Config flash based on HCLK
+		SN_FLASH->LPCTRL = 0x5AFA0000;
+
+		// Switch to KLRC
+        SN_SYS0->CLKCFG = 0x1;
+        while ((SN_SYS0->CLKCFG & 0x70) != 0x10);
+	#endif
+
+	// Switch to the final prescaler.
+	SN_SYS0->AHBCP = AHB_PRESCALAR;
+
+	#if (CLKOUT_SEL_VAL > 0)			//CLKOUT
+        SN_SYS1->AHBCLKEN_b.CLKOUTSEL 	= CLKOUT_SEL_VAL;
+        SN_SYS1->APBCP1_b.CLKOUTPRE 	= CLKOUT_PRESCALAR;
+	#endif
+#endif //(SYS_CLOCK_SETUP)
+
+}

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/SN32F260.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/SN32F260.ld
@@ -15,7 +15,7 @@
 */
 
 /*
- * SN32F240B memory setup.
+ * SN32F260 memory setup.
  * 0x200 entry point bootloader
  */
 MEMORY
@@ -84,3 +84,14 @@ REGION_ALIAS("HEAP_RAM", ram0);
 
 /* Generic rules inclusion.*/
 INCLUDE rules.ld
+
+/* Place magic value a the end of flash.*/
+_flag_start = 0x77FC;
+
+SECTIONS
+{
+    .flag _flag_start :
+    {
+        KEEP(*(.flag)) ;
+    } > flash0
+}

--- a/os/common/startup/ARMCMx/devices/SN32F26x/cmparams.h
+++ b/os/common/startup/ARMCMx/devices/SN32F26x/cmparams.h
@@ -15,10 +15,10 @@
 */
 
 /**
- * @file    SN32F24x/cmparams.h
+ * @file    SN32F26x/cmparams.h
  * @brief   ARM Cortex-M0 parameters for the SN32F24x.
  *
- * @defgroup ARMCMx_SN32F24x SN32F24x Specific Parameters
+ * @defgroup ARMCMx_SN32F26x SN32F26x Specific Parameters
  * @ingroup ARMCMx_SPECIFIC
  * @details This file contains the Cortex-M0 specific parameters for the
  *          SN32F24x platform.

--- a/os/hal/ports/SN32/SN32F260/hal_lld.c
+++ b/os/hal/ports/SN32/SN32F260/hal_lld.c
@@ -60,12 +60,6 @@ void sn32_clock_init(void) {
 
 }
 
-void SystemInit(void) {
-}
-
-void SystemCoreClockUpdate(void) {
-}
-
 /**
  * @brief   Low level HAL driver initialization.
  *

--- a/os/hal/ports/SN32/SN32F260/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F260/hal_lld.h
@@ -29,13 +29,13 @@
 /* Driver constants.                                                         */
 /*===========================================================================*/
 
-// #include "sn32_registry.h"
+#include "sn32_registry.h"
 
 /**
  * @name    Platform identification macros
  * @{
  */
-#define PLATFORM_NAME           "SN32F240x"
+#define PLATFORM_NAME           "SN32F26x"
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F260/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F260/sn32_registry.h
@@ -1,0 +1,115 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    sn32_registry.h
+ * @brief   SN32F26x capabilities registry.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef SN32_REGISTRY_H
+#define SN32_REGISTRY_H
+
+// There is some usage of SN32F24xx in:
+// - qmk_firmware/tmk_core/protocol/chibios/main.c
+// - qmk_firmware/tmk_core/common/chibios/suspend.c
+// - qmk_firmware/tmk_core/common/chibios/sleep_led.c
+// But it is me not really clear what this does.
+// SN32F24x and SN32F24xB both have this defines, so also define it here I guess
+#if !defined(SN32F24xx) || defined(__DOXYGEN__)
+#define SN32F24xx
+#endif
+
+/*===========================================================================*/
+/* Platform capabilities.                                                    */
+/*===========================================================================*/
+
+/**
+ * @name    SN32F26x capabilities
+ * @{
+ */
+
+/*
+ * ST unit
+ */
+#define SN32_ST_HANDLER           Vector3C
+#define SN32_ST_NUMBER            SysTick_IRQn
+
+/*
+ * NDT unit.
+ */
+#define SN32_NDT_HANDLER          Vector40
+#define SN32_NDT_NUMBER           NDT_IRQn
+
+/*
+ * USB unit.
+ */
+#define SN32_USB_HANDLER          Vector44
+#define SN32_USB_NUMBER           USB_IRQn
+
+/*
+ * SPI unit.
+ */
+#define SN32_SPI0_HANDLER          Vector74
+#define SN32_SPI0_NUMBER           SPI0_IRQn
+
+/*
+ * I2C unit.
+ */
+#define SN32_I2C0_GLOBAL_HANDLER   Vector7C
+#define SN32_I2C0_GLOBAL_NUMBER    I2C0_IRQn
+
+/*
+ * CT16 units.
+ */
+#define SN32_CT16B0_HANDLER       Vector80
+#define SN32_CT16B1_HANDLER       Vector84
+
+#define SN32_CT16B0_NUMBER        CT16B0_IRQn
+#define SN32_CT16B1_NUMBER        CT16B1_IRQn
+
+/*
+ * WDT unit.
+ */
+#define SN32_WDT_HANDLER          VectorA4
+#define SN32_WDT_NUMBER           WDT_IRQn
+
+/*
+ * LVD unit.
+ */
+#define SN32_LVD_HANDLER          VectorA8
+#define SN32_LVD_NUMBER           LVD_IRQn
+
+/*
+ * GPIO units.
+ */
+#define SN32_GPIOD_HANDLER        VectorB0
+#define SN32_GPIOC_HANDLER        VectorB4
+#define SN32_GPIOB_HANDLER        VectorB8
+#define SN32_GPIOA_HANDLER        VectorBC
+
+#define SN32_GPIOD_NUMBER         P3_IRQn
+#define SN32_GPIOC_NUMBER         P2_IRQn
+#define SN32_GPIOB_NUMBER         P1_IRQn
+#define SN32_GPIOA_NUMBER         P0_IRQn
+
+/** @} */
+
+#endif /* SN32_REGISTRY_H */
+
+/** @} */


### PR DESCRIPTION
Added files that where missing for SN32F260, that are existing for SN32F240 and SN32F240B.

Added sn32_registry.h. Now ISRs such as SN32_CT16B1_HANDLER can be used.
Added system_SN32F260.c. Now SystemInit() and SystemCoreClockUpdate() have an implementation.
Added .flag section. Now variable 'flag' with value 0xAAAA5555 is placed at the end of flash. Variable 'flag' is already defined in chibios-contrib/os/hal/boards/SN_SN32F260/board.c.
Fixed some copy-paste errors that mentioned SN32F240 instead of SN32F260.

This PR is lot smaller, so the changes are hopefully clearer.
Please comment or contact me if modifications are needed, so this can get merged.