### PR TITLE
Fix openrgb RAW set led drop issue

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F24xB/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F24xB/USB/hal_usb_lld.c
@@ -557,9 +557,15 @@ void handleNAK(USBDriver *usbp, usbep_t ep) {
 
     if(out)
     {
-        // By acking next OUT token from host we are allowing reception
-        // of the data from host
-        USB_EPnAck(ep, 0);
+        if (nakcnt[ep] < 1) {
+        	// NAK 1 time
+            USB_EPnNak(ep);
+            nakcnt[ep]++;
+        } else {
+        	// By acking next OUT token from host we are allowing reception
+        	// of the data from host        	
+            USB_EPnAck(ep, 0);            
+        }
     }
     else
     {


### PR DESCRIPTION
should handle nak if the device can't keep up PC writing speed (3~5 64-byte packets sequentially)