### PR TITLE
Override restart_usb_driver for SN32 to avoid kb crash on remote wakeup

### DIFF
--- a/os/hal/boards/SN_SN32F240B/board.c
+++ b/os/hal/boards/SN_SN32F240B/board.c
@@ -57,13 +57,16 @@ void __early_init(void) {
   sn32_clock_init();
 }
 
-
 /**
  * @brief   Board-specific initialization code.
  * @todo    Add your board-specific code, if any.
  */
 void boardInit(void) {
-  
+
   SN_SYS0->EXRSTCTRL_b.RESETDIS = 1; // Disable RESET
   SN_SYS0->SWDCTRL_b.SWDDIS = 1; // Disable SWD
+}
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on these boards breaks it.
 }

--- a/os/hal/boards/SN_SN32F260/board.c
+++ b/os/hal/boards/SN_SN32F260/board.c
@@ -75,3 +75,7 @@ void __early_init(void) {
 void boardInit(void) {
   SN_SYS0->SWDCTRL_b.SWDDIS = 1; // Disable SWD
 }
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on these boards breaks it.
+}


### PR DESCRIPTION
for history see:
https://github.com/SonixQMK/qmk_firmware/pull/28
https://github.com/qmk/qmk_firmware/pull/12870