### PR TITLE
Replaced symlink with regular file. Documented the workaround.

### DIFF
--- a/os/common/ext/SN/SN32F26x/SN32F240B.h
+++ b/os/common/ext/SN/SN32F26x/SN32F240B.h
@@ -1,1 +1,4 @@
-SN32F260.h
+// This file exists as a workaround to get the 240B USB code building on a 260.
+// Previously this was done with a symlink to SN32F260.h, but that doesn't work on Windows.
+// Now the #include directive is used to just include SN32F260.h
+#include "SN32F260.h"


### PR DESCRIPTION
This change was merged but got reverted.

But this should still be a issue for 260 builds under Windows. @gloryhzw Can you confirm this? You are using MSYS right?

Previous reverted commits:
https://github.com/SonixQMK/ChibiOS-Contrib/commit/1be226884c6caace49c5acfdd792b9a19f1d94a0
https://github.com/SonixQMK/ChibiOS-Contrib/commit/e1ed5548fb09daa431e16a5e541b852b873caa7b
