### PR TITLE
Fix compilation error

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c
+++ b/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c
@@ -40,8 +40,7 @@
 FLASH_Status FLASH_EraseSector (uint32_t adr)
 {
     // never touch the jumploader
-    if (adr < SN32_JUMPLOADER_SIZE)
-        return FLASH_FAIL;
+    if (adr < SN32_JUMPLOADER_SIZE) return FLASH_FAIL;
 
  	SN_FLASH->CTRL = FLASH_PER;						// Page Erase Enabled
 	SN_FLASH->ADDR = adr;									// Page Address
@@ -69,8 +68,7 @@ FLASH_Status FLASH_EraseSector (uint32_t adr)
 FLASH_Status FLASH_ProgramPage (uint32_t adr, uint32_t sz, uint32_t Data)
 {
     // never touch the jumploader
-    if (adr < SN32_JUMPLOADER_SIZE)
-        return FLASH_FAIL;
+    if (adr < SN32_JUMPLOADER_SIZE) return FLASH_FAIL;
 
 	SN_FLASH->CTRL = FLASH_PG;                  // Programming Enabled
 	SN_FLASH->ADDR = adr;


### PR DESCRIPTION
Fixing compilation error on arm-none-eabi-gcc 11.2
```
Compiling: lib/chibios-contrib/os/hal/boards/SN_SN32F240B/board.c                                  lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c: In function 'FLASH_EraseSector':
lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c:43:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   43 |     if (adr < SN32_JUMPLOADER_SIZE)
      |     ^~
In file included from lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.h:5,
                 from lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c:21:
./lib/chibios-contrib/os/common/ext/SN/SN32F24xB/SN32F240B.h:2740:37: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
 2740 | #define SN_FLASH                    ((SN_FLASH_Type*)          SN_FLASH_BASE)
      |                                     ^
lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c:46:9: note: in expansion of macro 'SN_FLASH'
   46 |         SN_FLASH->CTRL = FLASH_PER;                                             // Page Erase Enabled
      |         ^~~~~~~~
lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c: In function 'FLASH_ProgramPage':
lib/chibios-contrib/os/hal/ports/SN32/LLD/SN32F24xB/FLASH/Flash.c:72:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   72 |     if (adr < SN32_JUMPLOADER_SIZE)
      |     ^~
```