### PR TITLE
Remove flag

### DIFF
--- a/os/hal/boards/SN_SN32F260/board.c
+++ b/os/hal/boards/SN_SN32F260/board.c
@@ -52,21 +52,6 @@ void __early_init(void) {
   sn32_clock_init();
 }
 
-// void Reset_Handler(void) {
-//     setPinOutput(C4);
-//     setPinInputHigh(A0);
-//     if (readPin(A0) == 0) {
-//         asm ("mov %%sp, %0; bx %1;"
-//                 :
-//                 : "r"(0x200006C8), "r"(0x1fff0009)
-//                 : );
-//     }
-//     asm ("mov %%sp, %0; bx %1;"
-//             :
-//             : "r"(0x200006C8), "r"(0x7801)
-//             : );
-// }
-
 /**
  * @brief   Board-specific initialization code.
  */

--- a/os/hal/boards/SN_SN32F260/board.c
+++ b/os/hal/boards/SN_SN32F260/board.c
@@ -43,8 +43,6 @@ const PALConfig pal_default_config = {
 };
 #endif
 
-static int flag __attribute__((section(".flag"))) __attribute__((__used__)) = 0xAAAA5555;
-
 /**
  * @brief   Early initialization code.
  * @details This initialization must be performed just after stack setup


### PR DESCRIPTION
This PR removes the flag variable. The flag is a leftover from copying from 240B. 
On 240B the flag is needed, because it is checked by the bootloader to determine if flash contains valid firmware.
On 260 boards it is assumed that a jump-loader is used. The jump-loader has an other check to determine it there is valid firmware loaded into the flash. Therefor the flag is not needed.

Did some more clean-up, removed commented out code. 