### PR TITLE
sn32: platform definition updates

### DIFF
--- a/os/hal/ports/SN32/SN32F240/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F240/hal_lld.h
@@ -35,7 +35,7 @@
  * @name    Platform identification macros
  * @{
  */
-#define PLATFORM_NAME           "SN32F240x"
+#define PLATFORM_NAME           "SN32F24x"
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F240/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F240/sn32_registry.h
@@ -25,9 +25,9 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
-/* Common identifier of all SN32F24xx devices.*/
-#if !defined(SN32F24xx) || defined(__DOXYGEN__)
-#define SN32F24xx
+/* Common identifier of all SN32F2xx devices.*/
+#if !defined(SN32F2xx) || defined(__DOXYGEN__)
+#define SN32F2xx
 #endif
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F240/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F240/sn32_registry.h
@@ -15,8 +15,8 @@
 */
 
 /**
- * @file    sn32_registry.h
- * @brief   SN32F24xx capabilities registry.
+ * @file    SN32F240/sn32_registry.h
+ * @brief   SN32F24x capabilities registry.
  *
  * @addtogroup HAL
  * @{
@@ -25,6 +25,7 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
+/* Common identifier of all SN32F24xx devices.*/
 #if !defined(SN32F24xx) || defined(__DOXYGEN__)
 #define SN32F24xx
 #endif
@@ -34,9 +35,14 @@
 /*===========================================================================*/
 
 /**
- * @name    SN32F24xx capabilities
+ * @name    SN32F24x capabilities
  * @{
  */
+
+/* Common identifier of all SN32F24x devices.*/
+#if !defined(SN32F240) || defined(__DOXYGEN__)
+#define SN32F240
+#endif
 
 /*
  * ST unit

--- a/os/hal/ports/SN32/SN32F240B/hal_lld.h
+++ b/os/hal/ports/SN32/SN32F240B/hal_lld.h
@@ -35,7 +35,7 @@
  * @name    Platform identification macros
  * @{
  */
-#define PLATFORM_NAME           "SN32F240x"
+#define PLATFORM_NAME           "SN32F24xB"
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F240B/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F240B/sn32_registry.h
@@ -15,8 +15,8 @@
 */
 
 /**
- * @file    SN32F24xx/sn32_registry.h
- * @brief   SN32F24xx capabilities registry.
+ * @file    SN32F240B/sn32_registry.h
+ * @brief   SN32F24xB capabilities registry.
  *
  * @addtogroup HAL
  * @{
@@ -25,6 +25,7 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
+/* Common identifier of all SN32F24xx devices.*/
 #if !defined(SN32F24xx) || defined(__DOXYGEN__)
 #define SN32F24xx
 #endif
@@ -34,9 +35,14 @@
 /*===========================================================================*/
 
 /**
- * @name    SN32F24xx capabilities
+ * @name    SN32F24xB capabilities
  * @{
  */
+
+/* Common identifier of all SN32F24xB devices.*/
+#if !defined(SN32F240B) || defined(__DOXYGEN__)
+#define SN32F240B
+#endif
 
 /*
  * ST unit

--- a/os/hal/ports/SN32/SN32F240B/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F240B/sn32_registry.h
@@ -25,9 +25,9 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
-/* Common identifier of all SN32F24xx devices.*/
-#if !defined(SN32F24xx) || defined(__DOXYGEN__)
-#define SN32F24xx
+/* Common identifier of all SN32F2xx devices.*/
+#if !defined(SN32F2xx) || defined(__DOXYGEN__)
+#define SN32F2xx
 #endif
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/SN32F260/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F260/sn32_registry.h
@@ -15,7 +15,7 @@
 */
 
 /**
- * @file    sn32_registry.h
+ * @file    SN32F260/sn32_registry.h
  * @brief   SN32F26x capabilities registry.
  *
  * @addtogroup HAL
@@ -25,12 +25,7 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
-// There is some usage of SN32F24xx in:
-// - qmk_firmware/tmk_core/protocol/chibios/main.c
-// - qmk_firmware/tmk_core/common/chibios/suspend.c
-// - qmk_firmware/tmk_core/common/chibios/sleep_led.c
-// But it is me not really clear what this does.
-// SN32F24x and SN32F24xB both have this defines, so also define it here I guess
+/* Common identifier of all SN32F24xx devices.*/
 #if !defined(SN32F24xx) || defined(__DOXYGEN__)
 #define SN32F24xx
 #endif
@@ -43,6 +38,11 @@
  * @name    SN32F26x capabilities
  * @{
  */
+
+/* Common identifier of all SN32F26x devices.*/
+#if !defined(SN32F260) || defined(__DOXYGEN__)
+#define SN32F260
+#endif
 
 /*
  * ST unit

--- a/os/hal/ports/SN32/SN32F260/sn32_registry.h
+++ b/os/hal/ports/SN32/SN32F260/sn32_registry.h
@@ -25,9 +25,9 @@
 #ifndef SN32_REGISTRY_H
 #define SN32_REGISTRY_H
 
-/* Common identifier of all SN32F24xx devices.*/
-#if !defined(SN32F24xx) || defined(__DOXYGEN__)
-#define SN32F24xx
+/* Common identifier of all SN32F2xx devices.*/
+#if !defined(SN32F2xx) || defined(__DOXYGEN__)
+#define SN32F2xx
 #endif
 
 /*===========================================================================*/


### PR DESCRIPTION
This takes care of the platform names. 

Some clarification:
`SN32F2xx` is the name QMK might target for behavior stuff, namely the chip family
`SN32F240/B/60` is needed for use in the shared HAL when drivers target multiple chips, or when we need to be more specific.