### PR TITLE
Fix misconfiguration

### DIFF
--- a/os/hal/boards/SN_SN32F240B/board.c
+++ b/os/hal/boards/SN_SN32F240B/board.c
@@ -29,16 +29,16 @@
  */
 const PALConfig pal_default_config = {
   #if SN32_HAS_GPIOA
-  {VAL_GPIOA_MODE},
+  {.mode = VAL_GPIOA_MODE, .cfg = VAL_GPIOA_CFG},
   #endif
   #if SN32_HAS_GPIOB
-  {VAL_GPIOB_MODE},
+  {.mode = VAL_GPIOB_MODE, .cfg = VAL_GPIOB_CFG},
   #endif
   #if SN32_HAS_GPIOC
-  {VAL_GPIOC_MODE},
+  {.mode = VAL_GPIOC_MODE, .cfg = VAL_GPIOC_CFG},
   #endif
   #if SN32_HAS_GPIOD
-  {VAL_GPIOD_MODE},
+  {.mode = VAL_GPIOD_MODE, .cfg = VAL_GPIOD_CFG},
   #endif
 };
 #endif

--- a/os/hal/boards/SN_SN32F240B/board.h
+++ b/os/hal/boards/SN_SN32F240B/board.h
@@ -86,9 +86,6 @@
 #define GPIOC_PIN14 14U
 #define GPIOC_PIN15 15U
 
-// #define GPIOD_PIN0 0U
-// #define GPIOD_PIN1 1U
-// #define GPIOD_PIN2 2U
 #define GPIOD_PIN3 3U
 #define GPIOD_PIN4 4U
 #define GPIOD_PIN5 5U
@@ -98,123 +95,147 @@
 #define GPIOD_PIN9 9U
 #define GPIOD_PIN10 10U
 #define GPIOD_PIN11 11U
-// #define GPIOD_PIN12 12U
-// #define GPIOD_PIN13 13U
-// #define GPIOD_PIN14 14U
-// #define GPIOD_PIN15 15U
-
-
-/*
- * IO lines assignments.
- */
-// #define LINE_L3GD20_SDI PAL_LINE(GPIOA, 7U)
-// #define LINE_USB_DM PAL_LINE(GPIOA, 11U)
-// #define LINE_USB_DP PAL_LINE(GPIOA, 12U)
-#define LINE_SWDIO PAL_LINE(GPIOD, 5U)
-#define LINE_SWCLK PAL_LINE(GPIOD, 6U)
-
-// #define LINE_PINB8 PAL_LINE(GPIOB, 8U)
-// #define LINE_PINB9 PAL_LINE(GPIOB, 9U)
-
-//#define LINE_CAPS_LOCK PAL_LINE(GPIOC, 8U)
 
 /*
  * I/O ports initial setup, this configuration is established soon after reset
  * in the initialization code.
  * Please refer to the SN32 Reference Manual for details.
  */
-#define PIN_MODE_INPUT(n) (0U << ((n)))
-#define PIN_MODE_OUTPUT(n) (1U << ((n)))
-#define PIN_MODE_PULLUP(n) (0U << ((n*2)))
-#define PIN_MODE_SCHMITT_EN(n) (10U << ((n*2)))
-#define PIN_MODE_SCHMITT_DIS(n) (11U << ((n*2)))
+#define PIN_MODE_INPUT(n)       (0U << ((n)))
+#define PIN_MODE_OUTPUT(n)      (1U << ((n)))
 
-/*
- * GPIOA setup:
- *
- * PA0  - PIN0                      (input pullup).
- * PA1  - PIN1                      (input pullup).
- * PA2  - PIN2                      (input pullup).
- * PA3  - PIN3                      (input pullup).
- * PA4  - PIN4                      (input pullup).
- * PA5  - PIN5                      (input pullup).
- * PA6  - PIN6                      (input pullup).
- * PA7  - PIN7                      (input pullup).
- * PA8  - PIN8                      (input pullup).
- * PA9  - PIN9                      (input pullup).
- * PA11 - PIN10                     (input pullup).
- * PA11 - PIN11                     (input pullup).
- * PA12 - PIN12                     (input pullup).
- * PA13 - PIN13                     (input pullup).
- * PA14 - PIN14                     (input pullup).
- * PA15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOA_MODE (PIN_MODE_INPUT(GPIOA_PIN0) | PIN_MODE_INPUT(GPIOA_PIN1) | PIN_MODE_INPUT(GPIOA_PIN2) | PIN_MODE_INPUT(GPIOA_PIN3) | PIN_MODE_INPUT(GPIOA_PIN4) | PIN_MODE_INPUT(GPIOA_PIN5) | PIN_MODE_INPUT(GPIOA_PIN6) | PIN_MODE_INPUT(GPIOA_PIN7) | PIN_MODE_INPUT(GPIOA_PIN8) | PIN_MODE_INPUT(GPIOA_PIN9) | PIN_MODE_INPUT(GPIOA_PIN10) | PIN_MODE_INPUT(GPIOA_PIN11) | PIN_MODE_INPUT(GPIOA_PIN12) | PIN_MODE_INPUT(GPIOA_PIN13) | PIN_MODE_INPUT(GPIOA_PIN14) | PIN_MODE_INPUT(GPIOA_PIN15))
+#define PIN_CFG_PULLUP(n)       (0U << ((n*2))) // Pull-up
+#define PIN_CFG_SCHMITT_EN(n)   (2U << ((n*2))) // Floating
+#define PIN_CFG_SCHMITT_DIS(n)  (3U << ((n*2))) // Input buffer disconnected, alway read as zero.
 
-/*
- * GPIOB setup:
- *
- * PB0  - PIN0                      (input pullup).
- * PB1  - PIN1                      (input pullup).
- * PB2  - PIN2                      (input pullup).
- * PB3  - PIN3                      (input pullup).
- * PB4  - PIN4                      (input pullup).
- * PB5  - PIN5                      (input pullup).
- * PB6  - PIN6                      (input pullup).
- * PB7  - PIN7                      (input pullup).
- * PB8  - PIN8                      (input pullup).
- * PB9  - PIN9                      (input pullup).
- * PB10 - PIN10                     (input pullup).
- * PB11 - PIN11                     (input pullup).
- * PB12 - PIN12                     (input pullup).
- * PB13 - PIN13                     (input pullup).
- * PB14 - PIN14                     (input pullup).
- * PB15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOB_MODE (PIN_MODE_INPUT(GPIOB_PIN0) | PIN_MODE_INPUT(GPIOB_PIN1) | PIN_MODE_INPUT(GPIOB_PIN2) | PIN_MODE_INPUT(GPIOB_PIN3) | PIN_MODE_INPUT(GPIOB_PIN4) | PIN_MODE_INPUT(GPIOB_PIN5) | PIN_MODE_INPUT(GPIOB_PIN6) | PIN_MODE_OUTPUT(GPIOB_PIN7) | PIN_MODE_INPUT(GPIOB_PIN8) | PIN_MODE_INPUT(GPIOB_PIN9) | PIN_MODE_INPUT(GPIOB_PIN10) | PIN_MODE_INPUT(GPIOB_PIN11) | PIN_MODE_INPUT(GPIOB_PIN12) | PIN_MODE_INPUT(GPIOB_PIN13) | PIN_MODE_INPUT(GPIOB_PIN14) | PIN_MODE_INPUT(GPIOB_PIN15))
-/*
- * GPIOC setup:
- *
- * PC0  - PIN0                      (input pullup).
- * PC1  - PIN1                      (input pullup).
- * PC2  - PIN2                      (input pullup).
- * PC3  - PIN3                      (input pullup).
- * PC4  - PIN4                      (input pullup).
- * PC5  - PIN5                      (input pullup).
- * PC6  - PIN6                      (input pullup).
- * PC7  - PIN7                      (input pullup).
- * PC8  - PIN8                      (input pullup).
- * PC9  - PIN9                      (input pullup).
- * PC10 - PIN10                     (input pullup).
- * PC11 - PIN11                     (input pullup).
- * PC12 - PIN12                     (input pullup).
- * PC13 - PIN13                     (input pullup).
- * PC14 - PIN14                     (input pullup).
- * PC15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOC_MODE (PIN_MODE_INPUT(GPIOC_PIN0) | PIN_MODE_INPUT(GPIOC_PIN1) | PIN_MODE_INPUT(GPIOC_PIN2) | PIN_MODE_INPUT(GPIOC_PIN3) | PIN_MODE_INPUT(GPIOC_PIN4) | PIN_MODE_INPUT(GPIOC_PIN5) | PIN_MODE_INPUT(GPIOC_PIN6) | PIN_MODE_INPUT(GPIOC_PIN7) | PIN_MODE_INPUT(GPIOC_PIN8) | PIN_MODE_INPUT(GPIOC_PIN9) | PIN_MODE_INPUT(GPIOC_PIN10) | PIN_MODE_INPUT(GPIOC_PIN11) | PIN_MODE_INPUT(GPIOC_PIN12) | PIN_MODE_INPUT(GPIOC_PIN13) | PIN_MODE_INPUT(GPIOC_PIN14) | PIN_MODE_INPUT(GPIOC_PIN15))
+// Define GPIO register values used by pal_default_config.
+// The following values match the chip reset values, all GPIO pins as floating inputs.
 
-/*
- * GPIOD setup:
- *
- * PD0  - PIN0                      (input pullup).
- * PD1  - PIN1                      (input pullup).
- * PD2  - PIN2                      (input pullup).
- * PD3  - PIN3                      (input pullup).
- * PD4  - PIN4                      (input pullup).
- * PD5  - PIN5                      (input pullup).
- * PD6  - PIN6                      (input pullup).
- * PD7  - PIN7                      (input pullup).
- * PD8  - PIN8                      (input pullup).
- * PD9  - PIN9                      (input pullup).
- * PD11 - PIN10                     (input pullup).
- * PD11 - PIN11                     (input pullup).
- * PD12 - PIN12                     (input pullup).
- * PD13 - PIN13                     (input pullup).
- * PD14 - PIN14                     (input pullup).
- * PD15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOD_MODE (PIN_MODE_INPUT(GPIOD_PIN3) | PIN_MODE_INPUT(GPIOD_PIN4) | PIN_MODE_INPUT(GPIOD_PIN5) | PIN_MODE_INPUT(GPIOD_PIN6) | PIN_MODE_INPUT(GPIOD_PIN7) | PIN_MODE_INPUT(GPIOD_PIN8) | PIN_MODE_INPUT(GPIOD_PIN9) | PIN_MODE_INPUT(GPIOD_PIN10) | PIN_MODE_INPUT(GPIOD_PIN11))
+#define VAL_GPIOA_MODE \
+    ( PIN_MODE_INPUT(GPIOA_PIN0) \
+    | PIN_MODE_INPUT(GPIOA_PIN1) \
+    | PIN_MODE_INPUT(GPIOA_PIN2) \
+    | PIN_MODE_INPUT(GPIOA_PIN3) \
+    | PIN_MODE_INPUT(GPIOA_PIN4) \
+    | PIN_MODE_INPUT(GPIOA_PIN5) \
+    | PIN_MODE_INPUT(GPIOA_PIN6) \
+    | PIN_MODE_INPUT(GPIOA_PIN7) \
+    | PIN_MODE_INPUT(GPIOA_PIN8) \
+    | PIN_MODE_INPUT(GPIOA_PIN9) \
+    | PIN_MODE_INPUT(GPIOA_PIN10) \
+    | PIN_MODE_INPUT(GPIOA_PIN11) \
+    | PIN_MODE_INPUT(GPIOA_PIN12) \
+    | PIN_MODE_INPUT(GPIOA_PIN13) \
+    | PIN_MODE_INPUT(GPIOA_PIN14) \
+    | PIN_MODE_INPUT(GPIOA_PIN15) )
+#define VAL_GPIOA_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOA_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN10) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN11) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN12) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN13) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN14) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN15) )
+
+#define VAL_GPIOB_MODE \
+    ( PIN_MODE_INPUT(GPIOB_PIN0) \
+    | PIN_MODE_INPUT(GPIOB_PIN1) \
+    | PIN_MODE_INPUT(GPIOB_PIN2) \
+    | PIN_MODE_INPUT(GPIOB_PIN3) \
+    | PIN_MODE_INPUT(GPIOB_PIN4) \
+    | PIN_MODE_INPUT(GPIOB_PIN5) \
+    | PIN_MODE_INPUT(GPIOB_PIN6) \
+    | PIN_MODE_INPUT(GPIOB_PIN7) \
+    | PIN_MODE_INPUT(GPIOB_PIN8) \
+    | PIN_MODE_INPUT(GPIOB_PIN9) \
+    | PIN_MODE_INPUT(GPIOB_PIN10) \
+    | PIN_MODE_INPUT(GPIOB_PIN11) \
+    | PIN_MODE_INPUT(GPIOB_PIN12) \
+    | PIN_MODE_INPUT(GPIOB_PIN13) \
+    | PIN_MODE_INPUT(GPIOB_PIN14) \
+    | PIN_MODE_INPUT(GPIOB_PIN15) )
+#define VAL_GPIOB_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOB_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN10) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN11) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN12) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN13) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN14) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN15) )
+
+#define VAL_GPIOC_MODE \
+    ( PIN_MODE_INPUT(GPIOC_PIN0) \
+    | PIN_MODE_INPUT(GPIOC_PIN1) \
+    | PIN_MODE_INPUT(GPIOC_PIN2) \
+    | PIN_MODE_INPUT(GPIOC_PIN3) \
+    | PIN_MODE_INPUT(GPIOC_PIN4) \
+    | PIN_MODE_INPUT(GPIOC_PIN5) \
+    | PIN_MODE_INPUT(GPIOC_PIN6) \
+    | PIN_MODE_INPUT(GPIOC_PIN7) \
+    | PIN_MODE_INPUT(GPIOC_PIN8) \
+    | PIN_MODE_INPUT(GPIOC_PIN9) \
+    | PIN_MODE_INPUT(GPIOC_PIN10) \
+    | PIN_MODE_INPUT(GPIOC_PIN11) \
+    | PIN_MODE_INPUT(GPIOC_PIN12) \
+    | PIN_MODE_INPUT(GPIOC_PIN13) \
+    | PIN_MODE_INPUT(GPIOC_PIN14) \
+    | PIN_MODE_INPUT(GPIOC_PIN15) )
+#define VAL_GPIOC_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOC_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN10) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN11) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN12) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN13) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN14) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN15) )
+
+#define VAL_GPIOD_MODE \
+    ( PIN_MODE_INPUT(GPIOD_PIN3) \
+    | PIN_MODE_INPUT(GPIOD_PIN4) \
+    | PIN_MODE_INPUT(GPIOD_PIN5) \
+    | PIN_MODE_INPUT(GPIOD_PIN6) \
+    | PIN_MODE_INPUT(GPIOD_PIN7) \
+    | PIN_MODE_INPUT(GPIOD_PIN8) \
+    | PIN_MODE_INPUT(GPIOD_PIN9) \
+    | PIN_MODE_INPUT(GPIOD_PIN10) \
+    | PIN_MODE_INPUT(GPIOD_PIN11) )
+#define VAL_GPIOD_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOD_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN10) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN11) )
 
 #if !defined(_FROM_ASM_)
 #    ifdef __cplusplus

--- a/os/hal/boards/SN_SN32F260/board.c
+++ b/os/hal/boards/SN_SN32F260/board.c
@@ -29,16 +29,16 @@
  */
 const PALConfig pal_default_config = {
   #if SN32_HAS_GPIOA
-  {VAL_GPIOA_MODE},
+  {.mode = VAL_GPIOA_MODE, .cfg = VAL_GPIOA_CFG},
   #endif
   #if SN32_HAS_GPIOB
-  {VAL_GPIOB_MODE},
+  {.mode = VAL_GPIOB_MODE, .cfg = VAL_GPIOB_CFG},
   #endif
   #if SN32_HAS_GPIOC
-  {VAL_GPIOC_MODE},
+  {.mode = VAL_GPIOC_MODE, .cfg = VAL_GPIOC_CFG},
   #endif
   #if SN32_HAS_GPIOD
-  {VAL_GPIOD_MODE},
+  {.mode = VAL_GPIOD_MODE, .cfg = VAL_GPIOD_CFG},
   #endif
 };
 #endif

--- a/os/hal/boards/SN_SN32F260/board.h
+++ b/os/hal/boards/SN_SN32F260/board.h
@@ -58,16 +58,6 @@
 #define GPIOB_PIN3 3U
 #define GPIOB_PIN4 4U
 #define GPIOB_PIN5 5U
-#define GPIOB_PIN6 6U
-#define GPIOB_PIN7 7U
-#define GPIOB_PIN8 8U
-#define GPIOB_PIN9 9U
-#define GPIOB_PIN10 10U
-#define GPIOB_PIN11 11U
-#define GPIOB_PIN12 12U
-#define GPIOB_PIN13 13U
-#define GPIOB_PIN14 14U
-#define GPIOB_PIN15 15U
 
 #define GPIOC_PIN0 0U
 #define GPIOC_PIN1 1U
@@ -80,141 +70,127 @@
 #define GPIOC_PIN8 8U
 #define GPIOC_PIN9 9U
 #define GPIOC_PIN10 10U
-#define GPIOC_PIN11 11U
-#define GPIOC_PIN12 12U
-#define GPIOC_PIN13 13U
-#define GPIOC_PIN14 14U
-#define GPIOC_PIN15 15U
 
-// #define GPIOD_PIN0 0U
-// #define GPIOD_PIN1 1U
-// #define GPIOD_PIN2 2U
+#define GPIOD_PIN0 0U
+#define GPIOD_PIN1 1U
+#define GPIOD_PIN2 2U
 #define GPIOD_PIN3 3U
 #define GPIOD_PIN4 4U
 #define GPIOD_PIN5 5U
 #define GPIOD_PIN6 6U
 #define GPIOD_PIN7 7U
 #define GPIOD_PIN8 8U
-#define GPIOD_PIN9 9U
-#define GPIOD_PIN10 10U
-#define GPIOD_PIN11 11U
-// #define GPIOD_PIN12 12U
-// #define GPIOD_PIN13 13U
-// #define GPIOD_PIN14 14U
-// #define GPIOD_PIN15 15U
-
-
-/*
- * IO lines assignments.
- */
-// #define LINE_L3GD20_SDI PAL_LINE(GPIOA, 7U)
-// #define LINE_USB_DM PAL_LINE(GPIOA, 11U)
-// #define LINE_USB_DP PAL_LINE(GPIOA, 12U)
-#define LINE_SWDIO PAL_LINE(GPIOD, 5U)
-#define LINE_SWCLK PAL_LINE(GPIOD, 6U)
-
-// #define LINE_PINB8 PAL_LINE(GPIOB, 8U)
-// #define LINE_PINB9 PAL_LINE(GPIOB, 9U)
-
-#define LINE_CAPS_LOCK PAL_LINE(GPIOC, 8U)
 
 /*
  * I/O ports initial setup, this configuration is established soon after reset
  * in the initialization code.
  * Please refer to the SN32 Reference Manual for details.
  */
-#define PIN_MODE_INPUT(n) (0U << ((n)))
-#define PIN_MODE_OUTPUT(n) (1U << ((n)))
-#define PIN_MODE_PULLUP(n) (0U << ((n*2)))
-#define PIN_MODE_SCHMITT_EN(n) (10U << ((n*2)))
-#define PIN_MODE_SCHMITT_DIS(n) (11U << ((n*2)))
+#define PIN_MODE_INPUT(n)       (0U << ((n)))
+#define PIN_MODE_OUTPUT(n)      (1U << ((n)))
 
-/*
- * GPIOA setup:
- *
- * PA0  - PIN0                      (input pullup).
- * PA1  - PIN1                      (input pullup).
- * PA2  - PIN2                      (input pullup).
- * PA3  - PIN3                      (input pullup).
- * PA4  - PIN4                      (input pullup).
- * PA5  - PIN5                      (input pullup).
- * PA6  - PIN6                      (input pullup).
- * PA7  - PIN7                      (input pullup).
- * PA8  - PIN8                      (input pullup).
- * PA9  - PIN9                      (input pullup).
- * PA11 - PIN10                     (input pullup).
- * PA11 - PIN11                     (input pullup).
- * PA12 - PIN12                     (input pullup).
- * PA13 - PIN13                     (input pullup).
- * PA14 - PIN14                     (input pullup).
- * PA15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOA_MODE (PIN_MODE_INPUT(GPIOA_PIN0) | PIN_MODE_INPUT(GPIOA_PIN1) | PIN_MODE_INPUT(GPIOA_PIN2) | PIN_MODE_INPUT(GPIOA_PIN3) | PIN_MODE_INPUT(GPIOA_PIN4) | PIN_MODE_INPUT(GPIOA_PIN5) | PIN_MODE_INPUT(GPIOA_PIN6) | PIN_MODE_INPUT(GPIOA_PIN7) | PIN_MODE_INPUT(GPIOA_PIN8) | PIN_MODE_INPUT(GPIOA_PIN9) | PIN_MODE_INPUT(GPIOA_PIN10) | PIN_MODE_INPUT(GPIOA_PIN11) | PIN_MODE_INPUT(GPIOA_PIN12) | PIN_MODE_INPUT(GPIOA_PIN13) | PIN_MODE_INPUT(GPIOA_PIN14) | PIN_MODE_INPUT(GPIOA_PIN15))
+#define PIN_CFG_PULLUP(n)       (0U << ((n*2))) // Pull-up
+#define PIN_CFG_SCHMITT_EN(n)   (2U << ((n*2))) // Floating
+#define PIN_CFG_SCHMITT_DIS(n)  (3U << ((n*2))) // Input buffer disconnected, alway read as zero.
 
-/*
- * GPIOB setup:
- *
- * PB0  - PIN0                      (input pullup).
- * PB1  - PIN1                      (input pullup).
- * PB2  - PIN2                      (input pullup).
- * PB3  - PIN3                      (input pullup).
- * PB4  - PIN4                      (input pullup).
- * PB5  - PIN5                      (input pullup).
- * PB6  - PIN6                      (input pullup).
- * PB7  - PIN7                      (input pullup).
- * PB8  - PIN8                      (input pullup).
- * PB9  - PIN9                      (input pullup).
- * PB10 - PIN10                     (input pullup).
- * PB11 - PIN11                     (input pullup).
- * PB12 - PIN12                     (input pullup).
- * PB13 - PIN13                     (input pullup).
- * PB14 - PIN14                     (input pullup).
- * PB15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOB_MODE (PIN_MODE_INPUT(GPIOB_PIN0) | PIN_MODE_INPUT(GPIOB_PIN1) | PIN_MODE_INPUT(GPIOB_PIN2) | PIN_MODE_INPUT(GPIOB_PIN3) | PIN_MODE_INPUT(GPIOB_PIN4) | PIN_MODE_INPUT(GPIOB_PIN5) | PIN_MODE_INPUT(GPIOB_PIN6) | PIN_MODE_OUTPUT(GPIOB_PIN7) | PIN_MODE_INPUT(GPIOB_PIN8) | PIN_MODE_INPUT(GPIOB_PIN9) | PIN_MODE_INPUT(GPIOB_PIN10) | PIN_MODE_INPUT(GPIOB_PIN11) | PIN_MODE_INPUT(GPIOB_PIN12) | PIN_MODE_INPUT(GPIOB_PIN13) | PIN_MODE_INPUT(GPIOB_PIN14) | PIN_MODE_INPUT(GPIOB_PIN15))
-/*
- * GPIOC setup:
- *
- * PC0  - PIN0                      (input pullup).
- * PC1  - PIN1                      (input pullup).
- * PC2  - PIN2                      (input pullup).
- * PC3  - PIN3                      (input pullup).
- * PC4  - PIN4                      (input pullup).
- * PC5  - PIN5                      (input pullup).
- * PC6  - PIN6                      (input pullup).
- * PC7  - PIN7                      (input pullup).
- * PC8  - PIN8                      (input pullup).
- * PC9  - PIN9                      (input pullup).
- * PC10 - PIN10                     (input pullup).
- * PC11 - PIN11                     (input pullup).
- * PC12 - PIN12                     (input pullup).
- * PC13 - PIN13                     (input pullup).
- * PC14 - PIN14                     (input pullup).
- * PC15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOC_MODE (PIN_MODE_INPUT(GPIOC_PIN0) | PIN_MODE_INPUT(GPIOC_PIN1) | PIN_MODE_INPUT(GPIOC_PIN2) | PIN_MODE_INPUT(GPIOC_PIN3) | PIN_MODE_INPUT(GPIOC_PIN4) | PIN_MODE_INPUT(GPIOC_PIN5) | PIN_MODE_INPUT(GPIOC_PIN6) | PIN_MODE_INPUT(GPIOC_PIN7) | PIN_MODE_INPUT(GPIOC_PIN8) | PIN_MODE_INPUT(GPIOC_PIN9) | PIN_MODE_INPUT(GPIOC_PIN10) | PIN_MODE_INPUT(GPIOC_PIN11) | PIN_MODE_INPUT(GPIOC_PIN12) | PIN_MODE_INPUT(GPIOC_PIN13) | PIN_MODE_INPUT(GPIOC_PIN14) | PIN_MODE_INPUT(GPIOC_PIN15))
+// Define GPIO register values used by pal_default_config.
+// The following values match the chip reset values, all GPIO pins as floating inputs.
 
-/*
- * GPIOD setup:
- *
- * PD0  - PIN0                      (input pullup).
- * PD1  - PIN1                      (input pullup).
- * PD2  - PIN2                      (input pullup).
- * PD3  - PIN3                      (input pullup).
- * PD4  - PIN4                      (input pullup).
- * PD5  - PIN5                      (input pullup).
- * PD6  - PIN6                      (input pullup).
- * PD7  - PIN7                      (input pullup).
- * PD8  - PIN8                      (input pullup).
- * PD9  - PIN9                      (input pullup).
- * PD11 - PIN10                     (input pullup).
- * PD11 - PIN11                     (input pullup).
- * PD12 - PIN12                     (input pullup).
- * PD13 - PIN13                     (input pullup).
- * PD14 - PIN14                     (input pullup).
- * PD15 - PIN15                     (input pullup).
- */
-#define VAL_GPIOD_MODE (PIN_MODE_INPUT(GPIOD_PIN3) | PIN_MODE_INPUT(GPIOD_PIN4) | PIN_MODE_INPUT(GPIOD_PIN5) | PIN_MODE_INPUT(GPIOD_PIN6) | PIN_MODE_INPUT(GPIOD_PIN7) | PIN_MODE_INPUT(GPIOD_PIN8) | PIN_MODE_INPUT(GPIOD_PIN9) | PIN_MODE_INPUT(GPIOD_PIN10) | PIN_MODE_INPUT(GPIOD_PIN11))
+#define VAL_GPIOA_MODE \
+    ( PIN_MODE_INPUT(GPIOA_PIN0) \
+    | PIN_MODE_INPUT(GPIOA_PIN1) \
+    | PIN_MODE_INPUT(GPIOA_PIN2) \
+    | PIN_MODE_INPUT(GPIOA_PIN3) \
+    | PIN_MODE_INPUT(GPIOA_PIN4) \
+    | PIN_MODE_INPUT(GPIOA_PIN5) \
+    | PIN_MODE_INPUT(GPIOA_PIN6) \
+    | PIN_MODE_INPUT(GPIOA_PIN7) \
+    | PIN_MODE_INPUT(GPIOA_PIN8) \
+    | PIN_MODE_INPUT(GPIOA_PIN9) \
+    | PIN_MODE_INPUT(GPIOA_PIN10) \
+    | PIN_MODE_INPUT(GPIOA_PIN11) \
+    | PIN_MODE_INPUT(GPIOA_PIN12) \
+    | PIN_MODE_INPUT(GPIOA_PIN13) \
+    | PIN_MODE_INPUT(GPIOA_PIN14) \
+    | PIN_MODE_INPUT(GPIOA_PIN15) )
+#define VAL_GPIOA_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOA_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN10) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN11) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN12) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN13) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN14) \
+    | PIN_CFG_SCHMITT_EN(GPIOA_PIN15) )
+
+#define VAL_GPIOB_MODE \
+    ( PIN_MODE_INPUT(GPIOB_PIN0) \
+    | PIN_MODE_INPUT(GPIOB_PIN1) \
+    | PIN_MODE_INPUT(GPIOB_PIN2) \
+    | PIN_MODE_INPUT(GPIOB_PIN3) \
+    | PIN_MODE_INPUT(GPIOB_PIN4) \
+    | PIN_MODE_INPUT(GPIOB_PIN5) )
+#define VAL_GPIOB_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOB_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOB_PIN5) )
+
+#define VAL_GPIOC_MODE \
+    ( PIN_MODE_INPUT(GPIOC_PIN0) \
+    | PIN_MODE_INPUT(GPIOC_PIN1) \
+    | PIN_MODE_INPUT(GPIOC_PIN2) \
+    | PIN_MODE_INPUT(GPIOC_PIN3) \
+    | PIN_MODE_INPUT(GPIOC_PIN4) \
+    | PIN_MODE_INPUT(GPIOC_PIN5) \
+    | PIN_MODE_INPUT(GPIOC_PIN6) \
+    | PIN_MODE_INPUT(GPIOC_PIN7) \
+    | PIN_MODE_INPUT(GPIOC_PIN8) \
+    | PIN_MODE_INPUT(GPIOC_PIN9) \
+    | PIN_MODE_INPUT(GPIOC_PIN10) )
+#define VAL_GPIOC_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOC_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN8) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN9) \
+    | PIN_CFG_SCHMITT_EN(GPIOC_PIN10) )
+
+#define VAL_GPIOD_MODE \
+    ( PIN_MODE_INPUT(GPIOD_PIN0) \
+    | PIN_MODE_INPUT(GPIOD_PIN1) \
+    | PIN_MODE_INPUT(GPIOD_PIN2) \
+    | PIN_MODE_INPUT(GPIOD_PIN3) \
+    | PIN_MODE_INPUT(GPIOD_PIN4) \
+    | PIN_MODE_INPUT(GPIOD_PIN5) \
+    | PIN_MODE_INPUT(GPIOD_PIN6) \
+    | PIN_MODE_INPUT(GPIOD_PIN7) \
+    | PIN_MODE_INPUT(GPIOD_PIN8) )
+#define VAL_GPIOD_CFG \
+    ( PIN_CFG_SCHMITT_EN(GPIOD_PIN0) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN1) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN2) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN3) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN4) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN5) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN6) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN7) \
+    | PIN_CFG_SCHMITT_EN(GPIOD_PIN8) )
 
 #if !defined(_FROM_ASM_)
 #    ifdef __cplusplus


### PR DESCRIPTION
Fix for https://github.com/SonixQMK/ChibiOS-Contrib/issues/33

CFG is now also initialized, previous this was implicit zero initialized. This meant that pull-ups where enabled. 
But I think PIN_CFG_SCHMITT_EN is a better default, it the same as reset the value for that register.
This will prevent unwanted dim LEDs that are powered via pull-up etc.

Is there any reason to not change to PIN_CFG_SCHMITT_EN?

Did some extra clean-up of SN_SN32F260/board.h.

- [x] Fix and clean-up 260
- [x] Fix and clean-up 240B

