### PR TITLE
sn32: 2xx: USB: fix packet drops

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
@@ -213,7 +213,7 @@ static void usb_lld_serve_interrupt(USBDriver *usbp) {
     /* Get Interrupt Status and clear immediately. */
     iwIntFlag = SN32_USB->INSTS;
     /* Keep only PRESETUP & ERR_SETUP flags. */
-    SN32_USB->INSTSC = ~(mskEP0_PRESETUP | mskERR_SETUP);
+    SN32_USB->INSTSC &= ~(mskEP0_PRESETUP | mskERR_SETUP);
 
     if (iwIntFlag == 0) {
         //@20160902 add for EMC protection


### PR DESCRIPTION
This typo was causing packet drops on write after ~100k
thanks to @Jpe230 and @susch19 for tracing it

fixes OpenRGB support