### PR TITLE
Remove nack workaround for SN32F2xx

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.c
@@ -213,7 +213,7 @@ static void usb_lld_serve_interrupt(USBDriver *usbp) {
     /* Get Interrupt Status and clear immediately. */
     iwIntFlag = SN32_USB->INSTS;
     /* Keep only PRESETUP & ERR_SETUP flags. */
-    SN32_USB->INSTSC = ~(mskEP0_PRESETUP | mskERR_SETUP);
+    SN32_USB->INSTSC &= ~(mskEP0_PRESETUP | mskERR_SETUP);
 
     if (iwIntFlag == 0) {
         //@20160902 add for EMC protection


### PR DESCRIPTION
I've tested it with and without this workaround, with and without the package drop fix and with the package drop fix it works either way and without the package drop fix, the keyboard locks up after ~3 keypresses. Console didn't have any crashes, connection issues and every keystroke down and up was correctly logged. Shared ep was disabled during testing

#44 Should be merged first