### PR TITLE
Fix USB remote wakeup

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
@@ -390,7 +390,9 @@ struct USBDriver {
 #define usb_lld_wakeup_host(usbp)                                           \
   do {                                                                      \
     SN32_USB->SGCTL = (mskBUS_DRVEN|mskBUS_K_STATE);                        \
-    osalThreadSleepMilliseconds(SN32_USB_HOST_WAKEUP_DURATION);             \
+    uint32_t loops = OSAL_MS2I(SN32_USB_HOST_WAKEUP_DURATION) *             \
+                     (48000000 / CH_CFG_ST_FREQUENCY / 9);                  \
+    for (uint32_t i = 0; i < loops; i++) __NOP();                           \
     SN32_USB->SGCTL &= ~mskBUS_DRVEN;                                       \
   } while (false)
 

--- a/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/USB/hal_usb_lld.h
@@ -391,7 +391,7 @@ struct USBDriver {
   do {                                                                      \
     SN32_USB->SGCTL = (mskBUS_DRVEN|mskBUS_K_STATE);                        \
     uint32_t loops = OSAL_MS2I(SN32_USB_HOST_WAKEUP_DURATION) *             \
-                     (48000000 / CH_CFG_ST_FREQUENCY / 9);                  \
+                     (SN32_HCLK / CH_CFG_ST_FREQUENCY / 9);                  \
     for (uint32_t i = 0; i < loops; i++) __NOP();                           \
     SN32_USB->SGCTL &= ~mskBUS_DRVEN;                                       \
   } while (false)


### PR DESCRIPTION
Changing this 2 ms sleep to a busywait fixes USB remote wakeup on my Keychron C1 (white backlight version, 260). The old implementation of remote wakeup (from the now-removed usbhw.c) also busywaited instead of sleeping, so this is probably the correct solution and unlikely to cause problems.