### PR TITLE
SPI fixes

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
@@ -63,11 +63,7 @@ static void spi_lld_configure(SPIDriver *spip) {
 
   spip->spi->CTRL0 |= (spip->config->slave << 3);
   spip->spi->CTRL0_b.SDODIS = false;
-
-#if SPI_SELECT_MODE == SPI_SELECT_MODE_LLD
-  // Use hardware Auto-SEL
-  spip->spi->CTRL0_b.SELDIS = false;
-#endif
+  spip->spi->CTRL0_b.SELDIS = SPI_SELECT_MODE != SPI_SELECT_MODE_LLD;
 
   uint32_t sn32_spi_clock = (SN32_HCLK / ((2 * spip->config->clkdiv) + 2));
   if (sn32_spi_clock > 6000000) {

--- a/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
@@ -58,12 +58,13 @@ SPIDriver SPID1;
 
 static void spi_lld_configure(SPIDriver *spip) {
   spip->spi->CTRL0 = spip->config->ctrl0;
-  spip->spi->CTRL1 = (uint32_t)spip->config->ctrl1;
-  spip->spi->CLKDIV = (uint32_t)spip->config->clkdiv;
-
-  spip->spi->CTRL0 |= (spip->config->slave << 3);
-  spip->spi->CTRL0_b.SDODIS = false;
   spip->spi->CTRL0_b.SELDIS = SPI_SELECT_MODE != SPI_SELECT_MODE_LLD;
+  spip->spi->CTRL0_b.MS = spip->config->slave;
+  spip->spi->CTRL0_b.SDODIS = false;
+
+  spip->spi->CTRL1 = (uint32_t)spip->config->ctrl1;
+
+  spip->spi->CLKDIV = (uint32_t)spip->config->clkdiv;
 
   uint32_t sn32_spi_clock = (SN32_HCLK / ((2 * spip->config->clkdiv) + 2));
   if (sn32_spi_clock > 6000000) {

--- a/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.c
@@ -58,8 +58,8 @@ SPIDriver SPID1;
 
 static void spi_lld_configure(SPIDriver *spip) {
   spip->spi->CTRL0 = spip->config->ctrl0;
-  spip->spi->CTRL1 = spip->config->ctrl1;
-  spip->spi->CLKDIV = spip->config->clkdiv;
+  spip->spi->CTRL1 = (uint32_t)spip->config->ctrl1;
+  spip->spi->CLKDIV = (uint32_t)spip->config->clkdiv;
 
   spip->spi->CTRL0 |= (spip->config->slave << 3);
   spip->spi->CTRL0_b.SDODIS = false;

--- a/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/SPI/hal_spi_v2_lld.h
@@ -163,8 +163,8 @@
  */
 #define spi_lld_config_fields                                               \
   uint32_t                  ctrl0;                                          \
-  uint32_t                  ctrl1;                                          \
-  uint32_t                  clkdiv;
+  uint8_t                   ctrl1;                                          \
+  uint8_t                   clkdiv;
 
 
 /*===========================================================================*/

--- a/os/hal/ports/SN32/LLD/SN32F2xx/SPI/sn32_spi.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/SPI/sn32_spi.h
@@ -19,79 +19,80 @@
 
 typedef struct {
   union {
-    uint32_t CTRL0;
+    volatile uint32_t CTRL0;                    /*!< (@ 0x00000000) Offset:0x00 SPIn Control Register 0                        */
+
     struct {
-      uint32_t SPIEN : 1;
-      uint32_t LOOPBACK : 1;
-      uint32_t SDODIS : 1;
-      uint32_t MS : 1;
-      uint32_t FORMAT : 1;
-      uint32_t : 1;
-      uint32_t FRESET : 2;
-      uint32_t DL : 4;
-      uint32_t TXFIFOTH : 3;
-      uint32_t RXFIFOTH : 3;
-      uint32_t SELDIS : 1;
-      uint32_t : 13;
+      volatile uint32_t SPIEN      : 1;         /*!< [0..0] SPI enable                                                         */
+      volatile uint32_t LOOPBACK   : 1;         /*!< [1..1] Loopback mode enable                                               */
+      volatile uint32_t SDODIS     : 1;         /*!< [2..2] Slave data out disable                                             */
+      volatile uint32_t MS         : 1;         /*!< [3..3] Master/Slave selection                                             */
+      volatile uint32_t FORMAT     : 1;         /*!< [4..4] Interface format                                                   */
+               uint32_t            : 1;
+      volatile uint32_t FRESET     : 2;         /*!< [7..6] SPI FSM and FIFO Reset                                             */
+      volatile uint32_t DL         : 4;         /*!< [11..8] Data length = DL[3:0]+1                                           */
+      volatile uint32_t TXFIFOTH   : 3;         /*!< [14..12] TX FIFO Threshold level                                          */
+      volatile uint32_t RXFIFOTH   : 3;         /*!< [17..15] RX FIFO Threshold level                                          */
+      volatile uint32_t SELDIS     : 1;         /*!< [18..18] Auto-SEL disable bit                                             */
+               uint32_t            : 13;
     } CTRL0_b;
   };
 
-  uint32_t CTRL1;
-  uint32_t CLKDIV;
+  volatile uint32_t CTRL1;                      /*!< (@ 0x00000004) Offset:0x04 SPIn Control Register 1                        */
+  volatile uint32_t CLKDIV;                     /*!< (@ 0x00000008) Offset:0x08 SPIn Clock Divider Register                    */
 
   union {
-    uint32_t STAT;
+    volatile const uint32_t STAT;               /*!< (@ 0x0000000C) Offset:0x0C SPIn Status Register                           */
 
     struct {
-      uint32_t TX_EMPTY : 1;
-      uint32_t TX_FULL : 1;
-      uint32_t RX_EMPTY : 1;
-      uint32_t RX_FULL : 1;
-      uint32_t BUSY : 1;
-      uint32_t TXFIFOTHF : 1;
-      uint32_t RXFIFOTHF : 1;
-      uint32_t : 25;
+      volatile const uint32_t TX_EMPTY   : 1;   /*!< [0..0] TX FIFO empty flag                                                 */
+      volatile const uint32_t TX_FULL    : 1;   /*!< [1..1] TX FIFO full flag                                                  */
+      volatile const uint32_t RX_EMPTY   : 1;   /*!< [2..2] RX FIFO empty flag                                                 */
+      volatile const uint32_t RX_FULL    : 1;   /*!< [3..3] RX FIFO full flag                                                  */
+      volatile const uint32_t BUSY       : 1;   /*!< [4..4] Busy flag                                                          */
+      volatile const uint32_t TXFIFOTHF  : 1;   /*!< [5..5] TX FIFO threshold flag                                             */
+      volatile const uint32_t RXFIFOTHF  : 1;   /*!< [6..6] RX FIFO threshold flag                                             */
+                     uint32_t            : 25;
     } STAT_b;
   };
 
   union {
-    uint32_t IE;
+    volatile uint32_t IE;                       /*!< (@ 0x00000010) Offset:0x10 SPIn Interrupt Enable Register                 */
 
     struct {
-      uint32_t RXOVFIE : 1;
-      uint32_t RXTOIE : 1;
-      uint32_t RXFIFOTHIE : 1;
-      uint32_t TXFIFOTHIE : 1;
-      uint32_t : 28;
+      volatile uint32_t RXOVFIE    : 1;         /*!< [0..0] RX FIFO overflow interrupt enable                                  */
+      volatile uint32_t RXTOIE     : 1;         /*!< [1..1] RX time-out interrupt enable                                       */
+      volatile uint32_t RXFIFOTHIE : 1;         /*!< [2..2] RX FIFO threshold interrupt enable                                 */
+      volatile uint32_t TXFIFOTHIE : 1;         /*!< [3..3] TX FIFO threshold interrupt enable                                 */
+               uint32_t            : 28;
     } IE_b;
   };
 
   union {
-    uint32_t RIS;
+    volatile const uint32_t RIS;                /*!< (@ 0x00000014) Offset:0x14 SPIn Raw Interrupt Status Register             */
 
     struct {
-      uint32_t RXOVFIF : 1;
-      uint32_t RXTOIF : 1;
-      uint32_t RXFIFOTHIF : 1;
-      uint32_t TXFIFOTHIF : 1;
-      uint32_t : 28;
+      volatile const uint32_t RXOVFIF    : 1;   /*!< [0..0] RX FIFO overflow interrupt flag                                    */
+      volatile const uint32_t RXTOIF     : 1;   /*!< [1..1] RX time-out interrupt flag                                         */
+      volatile const uint32_t RXFIFOTHIF : 1;   /*!< [2..2] RX FIFO threshold interrupt flag                                   */
+      volatile const uint32_t TXFIFOTHIF : 1;   /*!< [3..3] TX FIFO threshold interrupt flag                                   */
+                     uint32_t            : 28;
     } RIS_b;
   };
 
   union {
-    uint32_t IC;
+    volatile uint32_t IC;                       /*!< (@ 0x00000018) Offset:0x18 SPIn Interrupt Clear Register                  */
 
     struct {
-      uint32_t RXOVFIC : 1;
-      uint32_t RXTOIC : 1;
-      uint32_t RXFIFOTHIC : 1;
-      uint32_t TXFIFOTHIC : 1;
-      uint32_t : 28;
+      volatile uint32_t RXOVFIC    : 1;         /*!< [0..0] RX FIFO overflow flag clear                                        */
+      volatile uint32_t RXTOIC     : 1;         /*!< [1..1] RX time-out interrupt flag clear                                   */
+      volatile uint32_t RXFIFOTHIC : 1;         /*!< [2..2] RX Interrupt flag Clear                                            */
+      volatile uint32_t TXFIFOTHIC : 1;         /*!< [3..3] TX Interrupt flag Clear                                            */
+               uint32_t            : 28;
     } IC_b;
   };
 
-  uint32_t DATA;
-  uint32_t DFDLY;
+  volatile uint32_t DATA;                       /*!< (@ 0x0000001C) Offset:0x1C SPIn Data Register                             */
+  volatile uint32_t DFDLY;                      /*!< (@ 0x00000020) Offset:0x20 SPIn Data Fetch Register                       */
 } sn32_spi_t;
 
 #endif /* SN32_SPI_H */


### PR DESCRIPTION
1. fixed missing `volatile` in SPI header (thanks to @dexter93)
2. fixed amount of memory used on stack. Rationale: there is no reason to keep in config not used bits
3. fixed disabling Auto-SEL with SPI mode other than SPI_SELECT_MODE_LLD