### PR TITLE
Small GPIO fix

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/GPIO/hal_pal_lld.h
@@ -340,7 +340,7 @@ typedef uint32_t iopadid_t;
  *
  * @notapi
  */
-#define pal_lld_clearport(port, bits) ((port)->BCLR = ~(uint32_t)(bits))
+#define pal_lld_clearport(port, bits) ((port)->BCLR = (uint32_t)(bits))
 
 /**
  * @brief   Writes a group of bits.


### PR DESCRIPTION
pal_lld_clearport function does not need inverted bits for BCLR register