### PR TITLE
fix(sn32 uart): remove non-locked osalSysUnlockFromISR

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/UART/hal_serial_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/UART/hal_serial_lld.c
@@ -311,7 +311,6 @@ static void serve_interrupt(SerialDriver *sdp) {
           break;
       }
           u->TH = b;
-          osalSysUnlockFromISR();
           ls = u->LS;
       }
     }


### PR DESCRIPTION
Small nitpick