### PR TITLE
fix(adc): Enable AIN16, AIN17, AIN18, few nitpicks

### DIFF
--- a/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.c
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.c
@@ -42,7 +42,7 @@ ADCDriver ADCD1;
 /*===========================================================================*/
 /* Driver local variables and types.                                         */
 /*===========================================================================*/
-#define ADC_CHANNEL_MASK 0x0F
+#define ADC_CHANNEL_MASK 0x1F
 /*===========================================================================*/
 /* Driver local functions.                                                   */
 /*===========================================================================*/
@@ -172,7 +172,6 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
   /* Apply ADC configuration.*/
   if(grpp->avrefhsel) adcSN32EnableAVREFHSEL(adcp);
   adcp->adc->ADM_b.VHS  = grpp->vhs;
-  adcSN32EnableGCHS(adcp->adc);
   adcp->adc->ADM_b.ADLEN  = grpp->adlen;
 
   adcp->number_of_samples = adcp->depth * grpp->num_channels;
@@ -191,6 +190,7 @@ void adc_lld_start_conversion(ADCDriver *adcp) {
   adcp->adc->RIS = 0U;
   adcp->adc->IE = ADC_IE_AIN(adcp->current_channel);
 
+  adcSN32EnableGCHS(adcp->adc);
   /* ADC conversion start.*/
   adcp->adc->ADM_b.ADS |= ADC_ADS_START;
 }

--- a/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.h
+++ b/os/hal/ports/SN32/LLD/SN32F2xx/ADC/hal_adc_lld.h
@@ -115,7 +115,7 @@
 /**
  * @brief   ADC wake-up procedure duration.
  */
-#if !defined(SN32_USB_HOST_WAKEUP_DURATION) || defined(__DOXYGEN__)
+#if !defined(SN32_ADC_WAKEUP_DURATION) || defined(__DOXYGEN__)
 #define SN32_ADC_WAKEUP_DURATION        100
 #endif
 
@@ -139,7 +139,7 @@
 #endif
 
 /* ADC IRQ priority tests.*/
-#if !OSAL_IRQ_IS_VALID_PRIORITY(SN32_ADC_ADC_IRQ_PRIORITY)
+#if !OSAL_IRQ_IS_VALID_PRIORITY(SN32_ADC_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to ADC"
 #endif
 


### PR DESCRIPTION
Add AIN16, AIN17, AIN18 as ADC channels:
<img width="1441" height="451" alt="image" src="https://github.com/user-attachments/assets/99940cf7-c028-4c40-bb02-ab075c625d77" />

Test with VDD measure(capped because power is USB 5V):
<img width="722" height="115" alt="image" src="https://github.com/user-attachments/assets/da64cd4e-dd3d-4519-a3fc-6a634c7ec47d" />
<img width="809" height="100" alt="image" src="https://github.com/user-attachments/assets/a6d7529c-bcba-4d89-87e9-56740562d2b3" />

Move GCHS after CHS as datasheet suggests